### PR TITLE
Update `kotlincrypto.core` to `0.2.6`

### DIFF
--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -2,7 +2,7 @@
 binaryCompat = "0.13.2"
 bouncyCastle = "1.73"
 configuration = "0.1.0"
-cryptoCore = "0.2.5"
+cryptoCore = "0.2.6"
 cryptoHash = "0.2.5"
 encoding = "1.2.2"
 gradleVersions = "0.46.0"


### PR DESCRIPTION
Closes #33 

The only changes made in `core` were to `Mac`, so want to get a CI build in just to check everything is kosher before doing another release.